### PR TITLE
Remove access function define

### DIFF
--- a/components/curl/lib/ssh.c
+++ b/components/curl/lib/ssh.c
@@ -397,58 +397,6 @@ static void state(struct connectdata *conn, sshstate nowstate)
   sshc->state = nowstate;
 }
 
-// ==== LoBo ===============================================
-
-int access (const char *file, int type)
-{
-struct stat stbuf;
-gid_t gid;
-uid_t uid;
-
-if (file == NULL || (type & ~(R_OK|W_OK|X_OK|F_OK)) != 0) {
-	errno = EINVAL;
-	return -1;
-}
-if(stat(file, &stbuf) == -1)
-	return -1;
-
-// No getgid() and getuid()? Well, we are God!
-//	gid = getgid();
-//	uid = getuid();
-uid = stbuf.st_uid;
-gid = stbuf.st_gid;
-
-if(uid == stbuf.st_uid) {
-	if( ((type & R_OK) && !(stbuf.st_mode & S_IRUSR) ) ||
-		((type & W_OK) && !(stbuf.st_mode & S_IWUSR) ) ||
-		((type & X_OK) && !(stbuf.st_mode & S_IXUSR) ) ) {
-		errno = EACCES;
-		return -1;
-	}
-}
-else if(gid == stbuf.st_gid) {
-	if( ((type & R_OK) && !(stbuf.st_mode & S_IRGRP) ) ||
-		((type & W_OK) && !(stbuf.st_mode & S_IWGRP) ) ||
-		((type & X_OK) && !(stbuf.st_mode & S_IXGRP) ) ) {
-		errno = EACCES;
-		return -1;
-	}
-}
-else {
-	if( ((type & R_OK) && !(stbuf.st_mode & S_IROTH) ) ||
-		((type & W_OK) && !(stbuf.st_mode & S_IWOTH) ) ||
-		((type & X_OK) && !(stbuf.st_mode & S_IXOTH) ) ) {
-		errno = EACCES;
-		return -1;
-	}
-}
-
-return 0;
-}
-
-// ==== LoBo ===============================================
-
-
 #ifdef HAVE_LIBSSH2_KNOWNHOST_API
 static int sshkeycallback(struct Curl_easy *easy,
                           const struct curl_khkey *knownkey, /* known */


### PR DESCRIPTION
This is now defined in esp32 idf so we don't need the custom define.